### PR TITLE
CustomTarget javadoc is incorrect

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/target/CustomTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/CustomTarget.java
@@ -61,8 +61,9 @@ public abstract class CustomTarget<T> implements Target<T> {
    * as the requested size (unless overridden by
    * {@link com.bumptech.glide.request.RequestOptions#override(int)} in the request).
    *
-   * @param width The requested width (>= 0, or == Target.SIZE_ORIGINAL).
-   * @param height The requested height (>= 0, or == Target.SIZE_ORIGINAL).
+   * @param width The requested width (> 0, or == Target.SIZE_ORIGINAL).
+   * @param height The requested height (> 0, or == Target.SIZE_ORIGINAL).
+   * @throws IllegalArgumentException if width/height doesn't meet (> 0, or == Target.SIZE_ORIGINAL)
    */
   public CustomTarget(int width, int height) {
      if (!Util.isValidDimensions(width, height)) {


### PR DESCRIPTION
`isValidDimensions` implementation enforces that width and height must be `> 0` or `== Target.SIZE_ORIGINAL`

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->